### PR TITLE
project: remove arrow function

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Leia nosso guia de contribuição [aqui](CONTRIBUTING.md)
 
 ## Contribuidores
 
-Ainda não temos, venha contribuir! :)
+| [<img src="https://avatars1.githubusercontent.com/u/8422610?&v=3&s=115"><br><sub>@thor99</sub>](https://github.com/thor99) |
+| :---: |
 
 
 ## Autor

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Por ser multifornecedor, a biblioteca irá chamar o callback com o fornecedor qu
 ``` js
 var cep = require('cep-callback')
 
-cep('05010000', (err, cepData) => {
+cep('05010000', function (err, cepData) {
   console.log(cepData)
 })
 
@@ -60,7 +60,7 @@ Em muitos sistemas o CEP é utilizado erroneamente como um Inteiro (e com isto c
 var cep = require('cep-callback')
 
 // enviando sem ter um zero à esquerda do CEP "05010000"
-cep(5010000, (err, cepData) => {
+cep(5010000, function (err, cepData) {
   console.log(cepData)
 })
 
@@ -80,7 +80,7 @@ Neste caso será retornado um `"service_error"` e por ser multifornecedor, a bib
 ``` js
 var cep = require('cep-callback')
 
-cep('99999999', (err, cepData) => {
+cep('99999999', function (err, cepData) {
   console.log(err)
 })
 
@@ -109,7 +109,7 @@ Neste caso será retornado um `"validation_error"` e a biblioteca irá retornar 
 ``` js
 var cep = require('cep-callback')
 
-cep('123456789123456789', (err, cepData) => {
+cep('123456789123456789', function (err, cepData) {
   console.log(err)
 })
 
@@ -149,7 +149,7 @@ $ bower install --save cep-callback
 ``` ts
 import * as cep from 'cep-callback'
 
-cep('05010000', (err, cepData) => {
+cep('05010000', function (err, cepData) {
   console.log(cepData)
 })
 ```

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -1,8 +1,8 @@
 var test = require('ava')
 var cep = require('../../src')
 
-test.cb('should return correct address with "05010000" string', t => {
-  cep('05010000', (err, cepData) => {
+test.cb('should return correct address with "05010000" string', function (t) {
+  cep('05010000', function (err, cepData) {
     t.is(err, null)
 
     t.deepEqual(cepData, {
@@ -17,8 +17,8 @@ test.cb('should return correct address with "05010000" string', t => {
   })
 })
 
-test.cb('should return correct address with a valid 5010000 number', t => {
-  cep(5010000, (err, cepData) => {
+test.cb('should return correct address with a valid 5010000 number', function (t) {
+  cep(5010000, function (err, cepData) {
     t.is(err, null)
 
     t.deepEqual(cepData, {
@@ -33,8 +33,8 @@ test.cb('should return correct address with a valid 5010000 number', t => {
   })
 })
 
-test.cb('should return error with an inexistent "99999999" CEP', t => {
-  cep('99999999', (err, cepData) => {
+test.cb('should return error with an inexistent "99999999" CEP', function (t) {
+  cep('99999999', function (err, cepData) {
     t.is(err.name, 'CepPromiseError')
     t.is(err.message, 'Todos os serviços de CEP retornaram erro.')
     t.is(err.type, 'service_error')
@@ -45,8 +45,8 @@ test.cb('should return error with an inexistent "99999999" CEP', t => {
   })
 })
 
-test.cb('should return validation error when invoked with an invalid "123456789" CEP', t => {
-  cep('123456789', (err, cepData) => {
+test.cb('should return validation error when invoked with an invalid "123456789" CEP', function (t) {
+  cep('123456789', function (err, cepData) {
     t.is(err.name, 'CepPromiseError')
     t.is(err.message, 'CEP deve conter exatamente 8 caracteres.')
     t.is(err.type, 'validation_error')
@@ -56,4 +56,3 @@ test.cb('should return validation error when invoked with an invalid "123456789"
     t.end()
   })
 })
-


### PR DESCRIPTION
Since we like (actually, we ARE) OldSchool, update project and remove arrow functions (hype person thing), to use old school `functions`. 

Also, add me as a contributor :)